### PR TITLE
Add SQLite caching for dictionary results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
-__pycache__
+__pycache__/
+bot.db

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ A Telegram bot that provides English word **meanings** and **translations** on r
 
 - 🔍 Get definitions for English words
 - 📌 Simple interface via Telegram chat
+- 💾 Caches looked-up definitions in a local SQLite database
 
 ### Planned Features (Coming Soon)
 
 - Generate [Anki](https://apps.ankiweb.net/) flashcards directly from words
 - Translate words to your native language
 - Generate sentence examples with provided word
-- Store words, meanings, and translations in a local database for review
+- Store translations in a local database for review
 
 
 ## Getting Started

--- a/db.py
+++ b/db.py
@@ -1,0 +1,42 @@
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path("bot.db")
+
+
+def init_db() -> None:
+    """Create the definitions table if it doesn't exist."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS definitions (
+            word TEXT PRIMARY KEY,
+            definition TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_definition(word: str) -> str | None:
+    """Return a cached definition if available."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT definition FROM definitions WHERE word = ?", (word,))
+    row = cur.fetchone()
+    conn.close()
+    return row[0] if row else None
+
+
+def save_definition(word: str, definition: str) -> None:
+    """Cache a definition for later use."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT OR REPLACE INTO definitions (word, definition) VALUES (?, ?)",
+        (word, definition),
+    )
+    conn.commit()
+    conn.close()


### PR DESCRIPTION
## Summary
- add SQLite helper module and cache dictionary lookups
- update bot to check cache before hitting Merriam-Webster API
- document local SQLite usage and ignore generated DB file

## Testing
- `python -m py_compile main.py dictionaries.py db.py`


------
https://chatgpt.com/codex/tasks/task_e_6895ff745cdc83259b3c5b4dbd84cf05