### PR TITLE
Add statistics and Anki export commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ A Telegram bot that provides English word **meanings** and **translations** on r
 - 🔍 Get definitions for English words
 - 📌 Simple interface via Telegram chat
 - 💾 Caches looked-up definitions in a local SQLite database
+- 📊 `/stats` command to show number of stored words
+- 📝 `/anki` command to export words as Anki flashcards
 
 ### Planned Features (Coming Soon)
 
-- Generate [Anki](https://apps.ankiweb.net/) flashcards directly from words
 - Translate words to your native language
 - Generate sentence examples with provided word
 - Store translations in a local database for review

--- a/db.py
+++ b/db.py
@@ -40,3 +40,23 @@ def save_definition(word: str, definition: str) -> None:
     )
     conn.commit()
     conn.close()
+
+
+def count_definitions() -> int:
+    """Return number of stored word definitions."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM definitions")
+    (count,) = cur.fetchone()
+    conn.close()
+    return count
+
+
+def get_all_definitions() -> list[tuple[str, str]]:
+    """Return all stored word-definition pairs."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT word, definition FROM definitions")
+    rows = cur.fetchall()
+    conn.close()
+    return rows


### PR DESCRIPTION
## Summary
- add `/stats` command to report count of stored words
- add `/anki` command exporting cached words as Anki-friendly TSV
- document new commands in README

## Testing
- `python -m py_compile db.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68960c42e0bc8325b6af2fda9cf025ce